### PR TITLE
Add omitting argument label

### DIFF
--- a/Donut/DonutView.swift
+++ b/Donut/DonutView.swift
@@ -70,8 +70,7 @@ open class DonutView: UIView {
         }
     }
 
-    public func removeCell(cell: DonutViewCell) {
-
+    public func removeCell(_ cell: DonutViewCell) {
         guard let index: Int = cells.index(of: cell) else { return }
         DispatchQueue.main.async { [weak self] in
             guard let me = self else { return }


### PR DESCRIPTION
Hi, I added omitting argument label into `removeCell` and remove unnecessary new line from top of the function body.